### PR TITLE
AWS Sdk update #266

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.mockito>1.10.19</version.mockito>
         <version.mustache>0.9.4</version.mustache>
         <version.vibur>17.0</version.vibur>
-        <version.aws>1.11.125</version.aws>
+        <version.aws>1.11.723</version.aws>
         <version.metrics>3.1.2</version.metrics>
         <version.protobuf>3.2.0</version.protobuf>
         <versions.rocker>0.23.0</versions.rocker>


### PR DESCRIPTION
Issue AWS Sdk update #266 update version from 1.11.125(Apr/17) to 1.11.723(Feb/20)

**Warning** The pom.xml files version are 2.1.7-Final, but there is a 2.1.8-Final jar at maven repository.

