### PR TITLE
Fix the special regex chars when they're part of file path (Windows)

### DIFF
--- a/kikaha-maven-plugin/source/kikaha/mojo/packager/ZipFileWriter.java
+++ b/kikaha-maven-plugin/source/kikaha/mojo/packager/ZipFileWriter.java
@@ -10,6 +10,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 @Getter
 public class ZipFileWriter {
 
+	private static final String WINDOWS_FILE_SEPARATOR = "\\";
+	private static final boolean IS_WINDOWS_FILE_SEPARATOR = WINDOWS_FILE_SEPARATOR.equals( File.separator );
+
 	final List<String> prefixesToStripOutFromName = new ArrayList<>();
 	final ZipOutputStream output;
 	final String fileName;
@@ -53,6 +56,7 @@ public class ZipFileWriter {
 	}
 
 	String fixEntryName( String entryName ) {
+		entryName = fixWindowsFileSeparator(entryName);
 		for ( final String prefix : prefixesToStripOutFromName )
 			entryName = entryName.replaceFirst( prefix, "" );
 		final String finalEntryName = rootDirectory + "/" + entryName;
@@ -69,6 +73,13 @@ public class ZipFileWriter {
 
 	public void stripPrefix( final String... prefixes ) {
 		for ( final String prefix : prefixes )
-			prefixesToStripOutFromName.add( prefix );
+			prefixesToStripOutFromName.add( fixWindowsFileSeparator(prefix) );
+	}
+
+	private String fixWindowsFileSeparator(String path) {
+		if ( IS_WINDOWS_FILE_SEPARATOR && path.contains(WINDOWS_FILE_SEPARATOR) ) {
+			path = path.replace( WINDOWS_FILE_SEPARATOR, "/" );
+		}
+		return path;
 	}
 }

--- a/kikaha-maven-plugin/tests/kikaha/mojo/packager/ZipFileWriterTest.java
+++ b/kikaha-maven-plugin/tests/kikaha/mojo/packager/ZipFileWriterTest.java
@@ -1,0 +1,18 @@
+package kikaha.mojo.packager;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+public class ZipFileWriterTest {
+
+    @Test
+    public void testFixEntryName() throws MojoExecutionException {
+        //Testing special regex chars like \k, \Q, \E and others
+        String[] pathsToTest = {"c:\\kikaha-test\\app", "c:\\Qope-test\\app", "c:\\Eoad-test\\app", "/Quit/test", "/kikaha-tes/c/app"};
+        ZipFileWriter zipFileWriter = new ZipFileWriter("output/generated-test.zip");
+        zipFileWriter.stripPrefix(pathsToTest);
+
+        for (String path : pathsToTest)
+            zipFileWriter.fixEntryName(path);
+    }
+}

--- a/kikaha-maven-plugin/tests/kikaha/mojo/packager/ZipFileWriterTest.java
+++ b/kikaha-maven-plugin/tests/kikaha/mojo/packager/ZipFileWriterTest.java
@@ -3,16 +3,20 @@ package kikaha.mojo.packager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class ZipFileWriterTest {
 
     @Test
     public void testFixEntryName() throws MojoExecutionException {
         //Testing special regex chars like \k, \Q, \E and others
-        String[] pathsToTest = {"c:\\kikaha-test\\app", "c:\\Qope-test\\app", "c:\\Eoad-test\\app", "/Quit/test", "/kikaha-tes/c/app"};
-        ZipFileWriter zipFileWriter = new ZipFileWriter("output/generated-test.zip");
-        zipFileWriter.stripPrefix(pathsToTest);
+        final String[] prefixesToTest = {"c:\\kikaha-test\\app", "c:\\Qope-test\\app", "c:\\Eoad-test\\app", "/Quit/test", "/kikaha-tes/c/app"};
+        final String additionalPath = "/conf/application.yaml";
+        final ZipFileWriter zipFileWriter = new ZipFileWriter("output/generated-test.zip");
+        zipFileWriter.stripPrefix(prefixesToTest);
 
-        for (String path : pathsToTest)
-            zipFileWriter.fixEntryName(path);
+        for (String prefix : prefixesToTest)
+            assertEquals(additionalPath, zipFileWriter.fixEntryName(prefix + additionalPath));
+
     }
 }


### PR DESCRIPTION
Fixing the special regex chars when they're part of file path (Windows) (e.g. c:\kikaha-test\test-app)

Some of these chars are \Q, \E, \k.

The problem occurs with deploy to Aws.