### PR TITLE
fix: sanitize system path based on the initial of the informed path

### DIFF
--- a/kikaha-maven-plugin/source/kikaha/mojo/packager/ZipFileWriter.java
+++ b/kikaha-maven-plugin/source/kikaha/mojo/packager/ZipFileWriter.java
@@ -12,7 +12,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 public class ZipFileWriter {
 
 	private static final String WINDOWS_PATH_SEPARATOR = "\\";
-	private static final String PREFIX_WINDOWS_PATH = "c:" + WINDOWS_PATH_SEPARATOR;
+  private static final String REGEX_PREFIX_WINDOWS_PATH = "^[a-zA-Z]:\\\\.*";
 
 	final List<String> prefixesToStripOutFromName = new ArrayList<>();
 	final ZipOutputStream output;
@@ -86,7 +86,7 @@ public class ZipFileWriter {
 	}
 
 	private boolean isWindowsPath(final String path) {
-		return path.startsWith(PREFIX_WINDOWS_PATH);
+		return path.matches(REGEX_PREFIX_WINDOWS_PATH);
 	}
 
 	private String sanitizePathToWindows(String path) {

--- a/kikaha-maven-plugin/source/kikaha/mojo/packager/ZipFileWriter.java
+++ b/kikaha-maven-plugin/source/kikaha/mojo/packager/ZipFileWriter.java
@@ -1,5 +1,6 @@
 package kikaha.mojo.packager;
 
+import static java.lang.System.getProperties;
 import static kikaha.mojo.packager.packager.*;
 import java.io.*;
 import java.util.*;
@@ -10,8 +11,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 @Getter
 public class ZipFileWriter {
 
-	private static final String WINDOWS_FILE_SEPARATOR = "\\";
-	private static final boolean IS_WINDOWS_FILE_SEPARATOR = WINDOWS_FILE_SEPARATOR.equals( File.separator );
+	private static final String WINDOWS_PATH_SEPARATOR = "\\";
+	private static final String PREFIX_WINDOWS_PATH = "c:" + WINDOWS_PATH_SEPARATOR;
 
 	final List<String> prefixesToStripOutFromName = new ArrayList<>();
 	final ZipOutputStream output;
@@ -56,7 +57,7 @@ public class ZipFileWriter {
 	}
 
 	String fixEntryName( String entryName ) {
-		entryName = fixWindowsFileSeparator(entryName);
+		entryName = sanitizePath(entryName);
 		for ( final String prefix : prefixesToStripOutFromName )
 			entryName = entryName.replaceFirst( prefix, "" );
 		final String finalEntryName = rootDirectory + "/" + entryName;
@@ -73,13 +74,23 @@ public class ZipFileWriter {
 
 	public void stripPrefix( final String... prefixes ) {
 		for ( final String prefix : prefixes )
-			prefixesToStripOutFromName.add( fixWindowsFileSeparator(prefix) );
+			prefixesToStripOutFromName.add( sanitizePath(prefix) );
 	}
 
-	private String fixWindowsFileSeparator(String path) {
-		if ( IS_WINDOWS_FILE_SEPARATOR && path.contains(WINDOWS_FILE_SEPARATOR) ) {
-			path = path.replace( WINDOWS_FILE_SEPARATOR, "/" );
+	private String sanitizePath(final String path) {
+		if(isWindowsPath(path)) {
+			return sanitizePathToWindows(path);
+		} else {
+			return path;
 		}
-		return path;
 	}
+
+	private boolean isWindowsPath(final String path) {
+		return path.startsWith(PREFIX_WINDOWS_PATH);
+	}
+
+	private String sanitizePathToWindows(String path) {
+		return path.replace( WINDOWS_PATH_SEPARATOR, "/" );
+	}
+
 }

--- a/kikaha-maven-plugin/tests/kikaha/mojo/packager/ZipFileWriterTest.java
+++ b/kikaha-maven-plugin/tests/kikaha/mojo/packager/ZipFileWriterTest.java
@@ -10,7 +10,7 @@ public class ZipFileWriterTest {
     @Test
     public void testFixEntryName() throws MojoExecutionException {
         //Testing special regex chars like \k, \Q, \E and others
-        final String[] prefixesToTest = {"c:\\kikaha-test\\app", "c:\\Qope-test\\app", "c:\\Eoad-test\\app", "/Quit/test", "/kikaha-tes/c/app"};
+        final String[] prefixesToTest = {"c:\\kikaha-test\\app", "d:\\Qope-test\\app", "l:\\Eoad-test\\app", "/Quit/test", "/kikaha-tes/c/app"};
         final String additionalPath = "/conf/application.yaml";
         final ZipFileWriter zipFileWriter = new ZipFileWriter("output/generated-test.zip");
         zipFileWriter.stripPrefix(prefixesToTest);


### PR DESCRIPTION
- Sanitize system path for Linux, Mac and Windows. 

Quoted by Miere https://github.com/Skullabs/kikaha/pull/276#issuecomment-603708405

When trying to run the tests in a linux environment, I got an error in the test:

**Class:** `ZipFileWriterTest`
**Method:** `testFixEntryName `
