### PR TITLE
fix: maven plugin compatible with most recent version maven 

### DIFF
--- a/kikaha-injection/pom.xml
+++ b/kikaha-injection/pom.xml
@@ -42,6 +42,11 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/kikaha-maven-plugin/pom.xml
+++ b/kikaha-maven-plugin/pom.xml
@@ -195,6 +195,15 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${version.compiler.plugin}</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.16</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 				<executions>
 					<execution>
 						<id>default-compile</id>


### PR DESCRIPTION
Quoted by Miere https://github.com/Skullabs/kikaha/issues/272#issue-569209791

> Due to old API being used, build breaks due to lack of compatibility of a few features. Once build though it is still runnable on 3.x version of Maven.
> 
> ## Expected behaviour
> Should be possible to build the Maven plugin using:
> 
> * modern version of the JDK
> * modern Maven 3.6 or superior

### This PR has the expected behaviors:

- [x] modern version of the JDK
- [x] modern Maven 3.6 or superior

**Note:** I ran the tests using kikaha in version 2.1.10.Final because in version 2.1.10-SNAPSHOT does not compile. 